### PR TITLE
research: draft-side INT4 (S+M1) for MTP 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,8 +159,7 @@ Current machine-readable result: `results/cache-spec-matrix-20260808-summary.jso
 |---|---:|---|---|
 | Current pinned nightly (Qwen Pi) | 1 | `patches/patch_mtp_nightly.py` | Build the preserved BF16 MTP draft outside the target GPTQ quant config |
 | Current pinned nightly (Qwen Pi) | 2 | `patches/patch_mtp_boundary.py` | Complete an exact-128K partial final MTP4 group without padding |
-| Current pinned nightly (Qwen Pi) | S | `patches/patch_draft_lmhead_int4.py` | Draft MTP LM head INT4 g128 sym (env `B70_DRAFT_LMHEAD_INT4=1`) — Phase S, ~+27% decode |
-| Current pinned nightly (Qwen Pi) | M1 | `patches/patch_draft_mtp_int4.py` | MTP module 5 linears INT4 g128 sym (env `B70_DRAFT_MTP_INT4=1`) — Phase M1, +7-9% more |
+| Qwen3.8 research only | — | `patches/patch_draft_lmhead_int4.py` / `patch_draft_mtp_int4.py` | Draft-side INT4 RTN. Env off by default. Same-image n=3 screen exists; not a cookbook keep until n=5 + accept counters. |
 | Nemotron DFlash (newer digest) | 1 | `patches/patch_xpu_grouped_topk_native_v2.py` | XPU native grouped-topk + `torch.compiler.disable` ([vllm#52159](https://github.com/vllm-project/vllm/pull/52159)) |
 | Nemotron DFlash | 2 | `patches/ssu-b70-b8w4/` | B70 SSU B8/W4 JSON (device-specific, ~1%) |
 | Optional kernels rebuild | — | `patches/vllm-xpu-kernels/0001-*.py` + `0002-*.py` | `at::zeros` + Muse tuple ([vllm-xpu-kernels#524](https://github.com/vllm-project/vllm-xpu-kernels/pull/524)) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,8 @@ Current machine-readable result: `results/cache-spec-matrix-20260808-summary.jso
 |---|---:|---|---|
 | Current pinned nightly (Qwen Pi) | 1 | `patches/patch_mtp_nightly.py` | Build the preserved BF16 MTP draft outside the target GPTQ quant config |
 | Current pinned nightly (Qwen Pi) | 2 | `patches/patch_mtp_boundary.py` | Complete an exact-128K partial final MTP4 group without padding |
+| Current pinned nightly (Qwen Pi) | S | `patches/patch_draft_lmhead_int4.py` | Draft MTP LM head INT4 g128 sym (env `B70_DRAFT_LMHEAD_INT4=1`) — Phase S, ~+27% decode |
+| Current pinned nightly (Qwen Pi) | M1 | `patches/patch_draft_mtp_int4.py` | MTP module 5 linears INT4 g128 sym (env `B70_DRAFT_MTP_INT4=1`) — Phase M1, +7-9% more |
 | Nemotron DFlash (newer digest) | 1 | `patches/patch_xpu_grouped_topk_native_v2.py` | XPU native grouped-topk + `torch.compiler.disable` ([vllm#52159](https://github.com/vllm-project/vllm/pull/52159)) |
 | Nemotron DFlash | 2 | `patches/ssu-b70-b8w4/` | B70 SSU B8/W4 JSON (device-specific, ~1%) |
 | Optional kernels rebuild | — | `patches/vllm-xpu-kernels/0001-*.py` + `0002-*.py` | `at::zeros` + Muse tuple ([vllm-xpu-kernels#524](https://github.com/vllm-project/vllm-xpu-kernels/pull/524)) |

--- a/docs/IMAGE-AND-PATCH-MATRIX.md
+++ b/docs/IMAGE-AND-PATCH-MATRIX.md
@@ -6,7 +6,7 @@ This cookbook has **two vLLM generations**. Pick the family first.
 |---|---|---|---|
 | Qwen3.6 Pi / dense 27B | `…2c427ef477da…` | `patch_mtp_nightly.py` then `patch_mtp_boundary.py` | Nemotron grouped-topk / SSU |
 | Nemotron-3.5-Lightning DFlash | `…1da0a9548545…` | `patch_xpu_grouped_topk_native_v2.py` then SSU B8/W4 | Qwen MTP patches |
-| Qwen3.8-27B | `…f01e24f6c7ff…` | `patch_mtp_nightly.py` then `patch_mtp_boundary.py` | none |
+| Qwen3.8-27B | `…f01e24f6c7ff…` | `patch_mtp_nightly.py` then `patch_mtp_boundary.py` | draft INT4 S+M1 until n=5 + accept; pair with compact+scatter GDN split, not the original full-buffer split |
 
 Nemotron-3.5-Lightning DFlash is a **second generation**. It uses a newer
 public digest than the Qwen3.6 Pi matrix below. Do not mix patch lists.

--- a/docs/IMAGE-AND-PATCH-MATRIX.md
+++ b/docs/IMAGE-AND-PATCH-MATRIX.md
@@ -1,12 +1,19 @@
 # vLLM XPU Image and Patch Matrix
 
-This cookbook has **two vLLM generations**. Pick the family first.
+This cookbook has **separate vLLM generations**. Pick the **family** first,
+then apply **only** that row’s “Apply” list. The last column is a
+**denylist**, not a second patch list.
 
-| Family | Digest | Patches | Do not apply |
+- **Qwen** (3.6 or 3.8) uses the **Qwen MTP** patches. Never put Nemotron
+  grouped-topk / SSU on a Qwen image.
+- **Nemotron DFlash** uses the **Nemotron** router + SSU patches. Never put
+  Qwen `patch_mtp_nightly.py` / `patch_mtp_boundary.py` on a Nemotron image.
+
+| Family | Image digest | Apply, in this order | Never apply on this family |
 |---|---|---|---|
-| Qwen3.6 Pi / dense 27B | `…2c427ef477da…` | `patch_mtp_nightly.py` then `patch_mtp_boundary.py` | Nemotron grouped-topk / SSU |
-| Nemotron-3.5-Lightning DFlash | `…1da0a9548545…` | `patch_xpu_grouped_topk_native_v2.py` then SSU B8/W4 | Qwen MTP patches |
-| Qwen3.8-27B | `…f01e24f6c7ff…` | `patch_mtp_nightly.py` then `patch_mtp_boundary.py` | draft INT4 S+M1 until n=5 + accept; pair with compact+scatter GDN split, not the original full-buffer split |
+| Qwen3.6 Pi / dense 27B | `…2c427ef477da…` | Qwen MTP: `patch_mtp_nightly.py` then `patch_mtp_boundary.py` | Nemotron grouped-topk / SSU (Nemotron-only) |
+| Nemotron-3.5-Lightning DFlash | `…1da0a9548545…` | Nemotron: `patch_xpu_grouped_topk_native_v2.py` then SSU B8/W4 | Qwen MTP patches (Qwen-only) |
+| Qwen3.8-27B | `…f01e24f6c7ff…` | Qwen MTP: `patch_mtp_nightly.py` then `patch_mtp_boundary.py`. Optional mixed-batch: compact+scatter `patch_gdn_mixed_split_v5.py` | Nemotron grouped-topk / SSU. Original full-buffer `patch_gdn_split_mixed` (OOB on kernels 0.1.12.3). Draft INT4 S+M1 stays research until a same-image n=5 + accept-counter card |
 
 Nemotron-3.5-Lightning DFlash is a **second generation**. It uses a newer
 public digest than the Qwen3.6 Pi matrix below. Do not mix patch lists.

--- a/docs/qwen38-27/DRAFT-INT4-S-M1.md
+++ b/docs/qwen38-27/DRAFT-INT4-S-M1.md
@@ -1,0 +1,77 @@
+# Qwen3.8-27B — Draft INT4 (S + M1) High-Throughput Variant
+
+Two extra runtime patches (apply after the base nightly patches **and** the
+concurrency/pointer-safety fixes) that quantize the **speculative-draft** side
+of MTP to INT4 g128 sym (GPTQ format), reusing the existing
+`torch.ops._xpu_C.int4_gemm_w4a16` kernel.
+
+**Lossless**: only the draft's own LM head / MTP module are quantized. The
+verification (target) LM head stays BF16, and draft tokens are verified
+against the target (greedy) — the emitted sequence is identical to the MTP4
+baseline.
+
+- `patches/patch_draft_lmhead_int4.py` (SHA-256: `ffae41926d5f05f4f38bb985301b5e572092441d06d6063c8820a63a39b8cefc`) — **Phase S**: draft LM head INT4 copy (2.54 GB fp16 → 0.66 GB), removes ~7.6 GB/step of DRAM reads (4 draft passes). Env `B70_DRAFT_LMHEAD_INT4=1`.
+- `patches/patch_draft_mtp_int4.py` (SHA-256: `4df179c3e77fd7a248f9b9c0b60217c60caea14ebfd16b7860536fbff3b2a1e9`) — **Phase M1**: the MTP module's 5 linears to INT4 (0.85 GB → ~0.22 GB), removes ~2.6 GB/step. Env `B70_DRAFT_MTP_INT4=1`.
+
+Both default **off** (exact baseline behavior when unset). Anchors are verified
+against the legacy Qwen pinned nightly (`vllm/vllm-openai-xpu@sha256:2c427ef477da…`,
+vLLM `0.26.1rc1.dev457`) and fail closed when they differ.
+
+## Launch
+
+```bash
+docker run -d --name b70-qwen38 -p 8010:8000 --device /dev/dri \
+  --group-add $(stat -c '%g' /dev/dri/render* | sort -u | sed -n '1p') \
+  -v /dev/dri:/dev/dri:ro -v /path/to/Qwen3.8-27B-GPTQ-Int4-sym-G128-MTP-BF16:/model:ro \
+  -v patches/patch_mtp_nightly.py:/patch_mtp.py:ro \
+  -v patches/patch_mtp_boundary.py:/patch_boundary.py:ro \
+  -v patches/patch_mtp_ptr_wrap.py:/patch_ptr_wrap.py:ro \
+  -v patches/patch_gdn_split_mixed.py:/patch_gdn_split.py:ro \
+  -v patches/patch_draft_lmhead_int4.py:/patch_loader_0.py:ro \
+  -v patches/patch_draft_mtp_int4.py:/patch_loader_1.py:ro \
+  -e VLLM_TARGET_DEVICE=xpu -e ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE -e ZE_AFFINITY_MASK=0 \
+  -e B70_MTP_BF16_DRAFT=1 -e VLLM_XPU_ENABLE_XPU_GRAPH=1 \
+  -e PYTORCH_ALLOC_CONF=expandable_segments:True \
+  -e B70_DRAFT_LMHEAD_INT4=1 -e B70_DRAFT_MTP_INT4=1 \
+  --entrypoint bash vllm/vllm-openai-xpu@sha256:2c427ef477da... -lc \
+  "set -e; python /patch_mtp.py; python /patch_boundary.py; python /patch_ptr_wrap.py; \
+   python /patch_gdn_split.py; python /patch_loader_0.py; python /patch_loader_1.py; \
+   exec vllm serve /model --quantization gptq --dtype float16 --max-model-len 131328 \
+   --gpu-memory-utilization 0.88 --kv-cache-dtype fp8 --port 8000 --max-num-seqs 64 \
+   --max-num-batched-tokens 4096 --enable-prefix-caching --language-model-only \
+   --speculative-config '{\"method\":\"mtp\",\"num_speculative_tokens\":4}'"
+```
+
+`--device /dev/dri` + the render GID (not `--privileged`), `--max-num-batched-tokens 4096`
+(+6.6% long-prefill), fp8 KV, U=0.88 (U=0.90 fills the card with MTP4) and
+prefix caching are the recommended production flags.
+
+## Results (measured 2026-08-16/17, harness C1, n=5, 230 W, B70)
+
+Same Qwen3.8-27B GPTQ-INT4 model (gptqmodel 7.3.2 quant), legacy nightly + the
+six-patch stack above. `client post-first tok/s`, median n=5:
+
+| Cell | Baseline (2 patches, new image) | **+6 patches (legacy nightly)** |
+|---|---|---|
+| p512/g128 | 83.7 | **117.1** |
+| p8192/g128 | 77.1 | **105.7** |
+
+Same-stack component deltas (measured on the heavy AutoRound quant): Phase S
+itself +27% (p8192/g32 71 → 90.4), S+M1 adds +7-9% more (96.5-98.4). MTP
+acceptance stays 0.88-0.98; the emitted greedy sequences are identical.
+
+Gate (legacy nightly + Qwen3.8, full six-patch stack):
+
+| Check | Result |
+|---|---|
+| Quality A (45) | 45/45 |
+| Sequential B (40) | 40/40 |
+| Concurrent C (8) | 8/8 |
+| Long context D (8K/32K) | OK |
+| MTP ratio | 0.58-0.61 |
+| HumanEval pass@1 (164, executed) | 92.7% |
+
+**E2 self-reported** on a single dual-GPU test bench; independent
+reproduction pending. The patches are runtime monkey-patches on a pinned
+nightly — upstreaming the INT4 draft path would require a build change in
+`vllm-xpu-kernels` and is left as future work.

--- a/docs/qwen38-27/DRAFT-INT4-S-M1.md
+++ b/docs/qwen38-27/DRAFT-INT4-S-M1.md
@@ -1,77 +1,74 @@
-# Qwen3.8-27B — Draft INT4 (S + M1) High-Throughput Variant
+# Qwen3.8-27B — Draft INT4 (S + M1) research variant
 
-Two extra runtime patches (apply after the base nightly patches **and** the
-concurrency/pointer-safety fixes) that quantize the **speculative-draft** side
-of MTP to INT4 g128 sym (GPTQ format), reusing the existing
-`torch.ops._xpu_C.int4_gemm_w4a16` kernel.
+Runtime patches that **requantize the speculative-draft side** of MTP to
+INT4 g128 symmetric (round-to-nearest, not Hessian GPTQ) and route those
+linears through `torch.ops._xpu_C.int4_gemm_w4a16`.
 
-**Lossless**: only the draft's own LM head / MTP module are quantized. The
-verification (target) LM head stays BF16, and draft tokens are verified
-against the target (greedy) — the emitted sequence is identical to the MTP4
-baseline.
+This is **not** the cookbook production recipe. The production Qwen3.8
+image is `vllm/vllm-openai-xpu@sha256:f01e24f6c7ff01f1e0662234255a1372297d1dbd89d003cf13c8fad3eab1ba4f`
+(vLLM `0.27.2rc1.dev77+gac7509e2b`, kernels `0.1.12.3`). These patches
+were authored against the **legacy** `2c427ef` nightly (vLLM 0.26.1).
+They fail closed if `qwen3_5_mtp.py` anchors differ.
 
-- `patches/patch_draft_lmhead_int4.py` (SHA-256: `ffae41926d5f05f4f38bb985301b5e572092441d06d6063c8820a63a39b8cefc`) — **Phase S**: draft LM head INT4 copy (2.54 GB fp16 → 0.66 GB), removes ~7.6 GB/step of DRAM reads (4 draft passes). Env `B70_DRAFT_LMHEAD_INT4=1`.
-- `patches/patch_draft_mtp_int4.py` (SHA-256: `4df179c3e77fd7a248f9b9c0b60217c60caea14ebfd16b7860536fbff3b2a1e9`) — **Phase M1**: the MTP module's 5 linears to INT4 (0.85 GB → ~0.22 GB), removes ~2.6 GB/step. Env `B70_DRAFT_MTP_INT4=1`.
+## What is and is not lossless
 
-Both default **off** (exact baseline behavior when unset). Anchors are verified
-against the legacy Qwen pinned nightly (`vllm/vllm-openai-xpu@sha256:2c427ef477da…`,
-vLLM `0.26.1rc1.dev457`) and fail closed when they differ.
-
-## Launch
-
-```bash
-docker run -d --name b70-qwen38 -p 8010:8000 --device /dev/dri \
-  --group-add $(stat -c '%g' /dev/dri/render* | sort -u | sed -n '1p') \
-  -v /dev/dri:/dev/dri:ro -v /path/to/Qwen3.8-27B-GPTQ-Int4-sym-G128-MTP-BF16:/model:ro \
-  -v patches/patch_mtp_nightly.py:/patch_mtp.py:ro \
-  -v patches/patch_mtp_boundary.py:/patch_boundary.py:ro \
-  -v patches/patch_mtp_ptr_wrap.py:/patch_ptr_wrap.py:ro \
-  -v patches/patch_gdn_split_mixed.py:/patch_gdn_split.py:ro \
-  -v patches/patch_draft_lmhead_int4.py:/patch_loader_0.py:ro \
-  -v patches/patch_draft_mtp_int4.py:/patch_loader_1.py:ro \
-  -e VLLM_TARGET_DEVICE=xpu -e ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE -e ZE_AFFINITY_MASK=0 \
-  -e B70_MTP_BF16_DRAFT=1 -e VLLM_XPU_ENABLE_XPU_GRAPH=1 \
-  -e PYTORCH_ALLOC_CONF=expandable_segments:True \
-  -e B70_DRAFT_LMHEAD_INT4=1 -e B70_DRAFT_MTP_INT4=1 \
-  --entrypoint bash vllm/vllm-openai-xpu@sha256:2c427ef477da... -lc \
-  "set -e; python /patch_mtp.py; python /patch_boundary.py; python /patch_ptr_wrap.py; \
-   python /patch_gdn_split.py; python /patch_loader_0.py; python /patch_loader_1.py; \
-   exec vllm serve /model --quantization gptq --dtype float16 --max-model-len 131328 \
-   --gpu-memory-utilization 0.88 --kv-cache-dtype fp8 --port 8000 --max-num-seqs 64 \
-   --max-num-batched-tokens 4096 --enable-prefix-caching --language-model-only \
-   --speculative-config '{\"method\":\"mtp\",\"num_speculative_tokens\":4}'"
-```
-
-`--device /dev/dri` + the render GID (not `--privileged`), `--max-num-batched-tokens 4096`
-(+6.6% long-prefill), fp8 KV, U=0.88 (U=0.90 fills the card with MTP4) and
-prefix caching are the recommended production flags.
-
-## Results (measured 2026-08-16/17, harness C1, n=5, 230 W, B70)
-
-Same Qwen3.8-27B GPTQ-INT4 model (gptqmodel 7.3.2 quant), legacy nightly + the
-six-patch stack above. `client post-first tok/s`, median n=5:
-
-| Cell | Baseline (2 patches, new image) | **+6 patches (legacy nightly)** |
-|---|---|---|
-| p512/g128 | 83.7 | **117.1** |
-| p8192/g128 | 77.1 | **105.7** |
-
-Same-stack component deltas (measured on the heavy AutoRound quant): Phase S
-itself +27% (p8192/g32 71 → 90.4), S+M1 adds +7-9% more (96.5-98.4). MTP
-acceptance stays 0.88-0.98; the emitted greedy sequences are identical.
-
-Gate (legacy nightly + Qwen3.8, full six-patch stack):
-
-| Check | Result |
+| Piece | After S+M1 |
 |---|---|
-| Quality A (45) | 45/45 |
-| Sequential B (40) | 40/40 |
-| Concurrent C (8) | 8/8 |
-| Long context D (8K/32K) | OK |
-| MTP ratio | 0.58-0.61 |
-| HumanEval pass@1 (164, executed) | 92.7% |
+| Target body (GPTQ-INT4) | unchanged |
+| Target / verify LM head | still FP16/BF16 |
+| Draft LM head copy | runtime INT4 g128 RTN |
+| Draft MTP 5 linears | runtime INT4 g128 RTN |
 
-**E2 self-reported** on a single dual-GPU test bench; independent
-reproduction pending. The patches are runtime monkey-patches on a pinned
-nightly — upstreaming the INT4 draft path would require a build change in
-`vllm-xpu-kernels` and is left as future work.
+Greedy **emitted** tokens can match the BF16-draft baseline because the
+target still verifies. Draft **logits are not** identical. Acceptance can
+drop. Do not call this a lossless speedup.
+
+## Hardware-feasible claim (not the original +51%)
+
+Decode on the B70 is GDDR6-bound. Quantizing a 2.5 GB vocab head that is
+reread on every draft pass is the right bottleneck class.
+
+The original PR table compared **83.7 (champion `f01e24f6`, 2 patches)**
+to **117.1 (legacy `2c427ef`, six patches, MBT 4096, prefix cache on)**.
+That is `not_comparable` / `best_cell_cross_result`, not a Phase S+M1 A/B.
+Do not headline +51% on the cookbook champion stack.
+
+Same-image n=3 screen on `f01e24f6` (2026-08-18,
+`B70-DOCS/results/qwen38-pr-ab-20260818T205619Z/`, C1 chat harness,
+configured 230 W, cache off, MBT 8192, **PROVISIONAL**):
+
+| Arm | p512/g128 median post-first | p8192/g1 input/TTFT | agentic 15-turn median |
+|---|---:|---:|---:|
+| cookbook MTP4 | 59.1 t/s (~p530) | 1748 t/s (~p4130) | 44.3 t/s |
+| v5 only | 62.7 | 1746 | 44.4 |
+| v5 + draft INT4 S+M1 | **83.9** | 1757 | **59.6** |
+
+Prefill is flat. The 83.9 cell matches the published cookbook Run 40 card
+(83.7 n=5 exact p512), it does **not** beat it. The +42% / +35% deltas
+are versus this campaign’s cookbook arm on the same chat harness, not
+versus 83.7. Acceptance counters were empty — do not claim lossless.
+
+Do not replace the cookbook C1 card with these n=3 numbers.
+
+## Required companion
+
+Stack with **GDN mixed-split v5** (`patches/patch_gdn_mixed_split_v5.py`),
+not the original PR #1 full-buffer split. The original split is OOB on
+kernels 0.1.12.3 (host `narrow` + global `token_indx`).
+
+Pointer wrap (`patch_mtp_ptr_wrap.py`) is optional and **int64-only**.
+Do not signed-wrap uint64 `dst_ptrs_np`.
+
+## Env
+
+- `B70_DRAFT_LMHEAD_INT4=1` — Phase S (default off)
+- `B70_DRAFT_MTP_INT4=1` — Phase M1 (default off)
+
+## Status
+
+**PROVISIONAL — NOT FOR PUBLIC HEADLINE.** Same-image (`f01e24f6`) n=3
+screen exists (table above). Still need n≥5 exact-token C1 plus
+`spec_decode` accepted/proposed counters before a recipe keep.
+
+Author self-report (E2, legacy image, +51%) is retained in the PR
+discussion. It is not a cookbook result card.

--- a/docs/qwen38-27/QWEN38-VLLM-XPU.md
+++ b/docs/qwen38-27/QWEN38-VLLM-XPU.md
@@ -161,3 +161,11 @@ Sampling parameters are set per thinking mode by the extension
 Qwen3.8-27B model card — thinking `temperature=1.0, top_p=0.95, top_k=20,
 presence_penalty=0.0`; non-thinking `temperature=0.7, top_p=0.80, top_k=20,
 presence_penalty=1.5`; `repetition_penalty=1.0` both modes.
+
+## 11. Draft INT4 S+M1 (research, env default off)
+
+See [DRAFT-INT4-S-M1.md](DRAFT-INT4-S-M1.md). Do not headline +51% against
+this champion recipe. Pair with a compact+scatter GDN split if you also
+need mixed spec + prefill; the original full-buffer split is OOB on
+kernels 0.1.12.3.
+

--- a/patches/patch_draft_lmhead_int4.py
+++ b/patches/patch_draft_lmhead_int4.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""B70 Fase S: draft MTP LM head cuantizado a INT4 g128 sym (GPTQ format).
+
+El LM head fp16 compartido (5120x248320 = 2.54 GB) se lee 5x/paso MTP4
+(4 drafts + 1 target) = 12.7 GB/step a ~98% del pico de DRAM (21.3 ms,
+41% del tiempo de GEMM). Cuantizar SOLO la copia del draft a INT4 g128 sym
+(0.66 GB/paso incl. scales) reduce las 4 pasadas del draft a ~4x0.66 GB
+→ -7.6 GB/step ≈ -13 ms/step → objetivo ~108 tok/s.
+
+Lossless: el draft MTP usa SU PROPIO lm_head (DraftModelProposer._maybe_share
+_lm_head es no-op — no comparte el del target). Cuantizar la copia del draft
+no toca el target de verificacion (fp16) y los tokens del draft se verifican
+contra el target: la secuencia emitida es identica a MTP4 baseline (greedy).
+
+Formato del peso INT4 = exactamente el que consume la op YA existente
+``torch.ops._xpu_C.int4_gemm_w4a16`` (el que usan los layers INC/GPTQ del
+cuerpo): qweight int32 [K/8, N] NT (nibbles secuenciales LSB-first,
+valor almacenado = q + 8), scales fp16 [K/128, N], qzeros int8 [1] = 8.
+
+Env-gated: B70_DRAFT_LMHEAD_INT4=1 (default off = comportamiento identico).
+Anclas verificadas contra la imagen vllm/vllm-openai-xpu@2c427ef (vLLM
+0.26.1.dev457.gc810e5ee9).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+MARKER = "B70_DRAFT_LMHEAD_INT4"
+
+HELPER_MODULE = "b70_draft_lmhead_int4.py"
+
+HELPER_SOURCE = '''\
+"""B70 Fase S runtime helper: draft MTP LM head INT4 g128 sym.
+
+Escribido por patch_draft_lmhead_int4.py dentro del contenedor. Provee la
+cuantizacion one-time del lm_head fp16 compartido a GPTQ INT4 g128 sym y el
+ruteo de las 4 pasadas del draft por ``int4_gemm_w4a16``. El target queda
+fp16 (lossless).
+"""
+from __future__ import annotations
+
+import os
+
+import torch
+
+
+def quantize_lmhead_to_int4(weight: torch.Tensor, group_size: int = 128):
+    """Quantiza un lm_head fp16 [N, K] a GPTQ INT4 g128 sym.
+
+    Returns (qweight, scales, qzeros, group_size):
+      qweight: int32 [K//8, N] en layout NT (strides[-2] == 1), nibbles
+               secuenciales LSB-first, valor almacenado = q + 8 (q in [-8, 7])
+      scales:  fp16 [K//group_size, N]
+      qzeros:  int8 tensor([8])  -> rama simetrica de int4_gemm_w4a16
+    """
+    device = weight.device
+    N, K = weight.shape
+    num_groups = K // group_size
+    chunk = 4096
+    shifts = torch.tensor(
+        [0, 4, 8, 12, 16, 20, 24, 28], dtype=torch.int32, device=device
+    )
+    parts = []
+    scale_parts = []
+    for i in range(0, N, chunk):
+        wc = weight[i : i + chunk].float()  # [c, K] fp32 (chunked: no 5 GB temp)
+        wg = wc.view(wc.shape[0], num_groups, group_size)
+        maxabs = wg.abs().amax(dim=-1)  # [c, g]
+        scale = maxabs / 7.0
+        q = (wg / scale.unsqueeze(-1)).round().clamp(-8, 7).to(torch.int32)
+        stored = q + 8  # 0..15
+        qv = stored.view(wc.shape[0], num_groups, group_size // 8, 8)
+        packed = (qv << shifts).sum(dim=-1).to(torch.int32).reshape(
+            wc.shape[0], K // 8
+        )
+        parts.append(packed)
+        scale_parts.append(scale.half())
+    qweight_contig = torch.cat(parts, dim=0)  # [N, K//8] int32
+    scales_contig = torch.cat(scale_parts, dim=0)  # [N, g] fp16
+    # Layout NT requerido por la op (strides[-2] == 1) + scales contiguas
+    qweight = qweight_contig.t()  # [K//8, N], strides (1, K//8)
+    scales = scales_contig.t().contiguous()  # [g, N]
+    qzeros = torch.tensor([8], dtype=torch.int8, device=device)
+    return qweight, scales, qzeros, group_size
+
+
+def int4_lmhead_logits(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+    qzeros: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    """Logits [.., vocab] via int4_gemm_w4a16 (mismo formato que el cuerpo)."""
+    flat = x.reshape(-1, x.shape[-1])
+    logits = torch.ops._xpu_C.int4_gemm_w4a16(
+        flat, qweight, None, scales, qzeros, group_size, None
+    )
+    return logits.reshape(*x.shape[:-1], qweight.shape[1])
+
+
+@torch.no_grad()
+def build_draft_lmhead_int4(model) -> None:
+    """Cuantiza el lm_head fp16 compartido del draft (one-time, no-op si no
+    hay env gate o si ya se construyo). Almacena en model._b70_lmhead_int4."""
+    if os.environ.get("B70_DRAFT_LMHEAD_INT4") != "1":
+        return
+    if getattr(model, "_b70_lmhead_int4", None) is not None:
+        return
+    head = getattr(model, "lm_head", None)
+    weight = getattr(head, "weight", None)
+    if weight is None:
+        print("[B70] draft LM head INT4: lm_head.weight no disponible; "
+              "draft sigue por fp16", flush=True)
+        return
+    print("[B70] draft LM head INT4: cuantizando lm_head fp16 "
+          f"{tuple(weight.shape)} -> INT4 g128 sym (one-time)", flush=True)
+    qweight, scales, qzeros, group_size = quantize_lmhead_to_int4(
+        weight.detach()
+    )
+    model._b70_lmhead_int4 = (qweight, scales, qzeros, group_size)
+    fp16_bytes = weight.numel() * weight.element_size()
+    int4_bytes = qweight.numel() * qweight.element_size() + (
+        scales.numel() * scales.element_size()
+    )
+    print(f"[B70] draft LM head INT4: listo. {fp16_bytes/1e9:.2f} GB fp16 -> "
+          f"{int4_bytes/1e9:.2f} GB INT4 (ahorro "
+          f"{(fp16_bytes - int4_bytes)/1e6:.1f} MB/lectura)", flush=True)
+
+
+def draft_lmhead_int4_logits(model, hidden_states: torch.Tensor) -> torch.Tensor:
+    """Logits del draft via la copia INT4 (4 pasadas/paso -> 0.66 GB c/u)."""
+    qweight, scales, qzeros, group_size = model._b70_lmhead_int4
+    logits = int4_lmhead_logits(
+        hidden_states, qweight, scales, qzeros, group_size
+    )
+    org = getattr(getattr(model, "logits_processor", None), "org_vocab_size", None)
+    if org is not None and logits.shape[-1] > org:
+        logits = logits[..., :org]
+    return logits
+'''
+
+QWMTP_OLD = (
+    "    def compute_logits(\n"
+    "        self,\n"
+    "        hidden_states: torch.Tensor,\n"
+    "        spec_step_idx: int = 0,\n"
+    "    ) -> torch.Tensor | None:\n"
+    "        return self.logits_processor(self.lm_head, hidden_states)\n"
+)
+QWMTP_NEW = (
+    "    def compute_logits(\n"
+    "        self,\n"
+    "        hidden_states: torch.Tensor,\n"
+    "        spec_step_idx: int = 0,\n"
+    "    ) -> torch.Tensor | None:\n"
+    "        if os.environ.get(\"B70_DRAFT_LMHEAD_INT4\") == \"1\":\n"
+    "            from vllm.model_executor.models.b70_draft_lmhead_int4 import (\n"
+    "                build_draft_lmhead_int4,\n"
+    "                draft_lmhead_int4_logits,\n"
+    "            )\n"
+    "\n"
+    "            if getattr(self, \"_b70_lmhead_int4\", None) is None:\n"
+    "                build_draft_lmhead_int4(self)\n"
+    "            if getattr(self, \"_b70_lmhead_int4\", None) is not None:\n"
+    "                return draft_lmhead_int4_logits(self, hidden_states)\n"
+    "        return self.logits_processor(self.lm_head, hidden_states)\n"
+)
+
+
+def _write_helper(vllm_dir: str) -> str:
+    models_dir = os.path.join(vllm_dir, "model_executor", "models")
+    os.makedirs(models_dir, exist_ok=True)
+    path = os.path.join(models_dir, HELPER_MODULE)
+    existing = None
+    if os.path.exists(path):
+        existing = open(path).read()
+    if existing == HELPER_SOURCE:
+        print(f"helper already present {path}")
+        return path
+    with open(path, "w") as f:
+        f.write(HELPER_SOURCE)
+    print(f"helper written {path}")
+    return path
+
+
+def _patch_qwen3_5_mtp(vllm_dir: str) -> None:
+    path = os.path.join(vllm_dir, "model_executor", "models", "qwen3_5_mtp.py")
+    text = open(path).read()
+    if MARKER in text:
+        print(f"already patched {path}")
+        return
+    if QWMTP_OLD not in text:
+        sys.exit(f"anchor not found in {path}: compute_logits")
+    text = text.replace(QWMTP_OLD, QWMTP_NEW, 1)
+    if "\nimport os\n" not in text and not text.startswith("import os\n"):
+        text = text.replace("import torch\n", "import os\nimport torch\n", 1)
+        if "\nimport os\n" not in text and not text.startswith("import os\n"):
+            sys.exit(f"could not inject import os in {path}")
+    compile(text, path, "exec")
+    open(path, "w").write(text)
+    print(f"patched {path}")
+
+
+def main() -> None:
+    import vllm
+
+    vllm_dir = os.path.dirname(vllm.__file__)
+    _write_helper(vllm_dir)
+    _patch_qwen3_5_mtp(vllm_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/patches/patch_draft_mtp_int4.py
+++ b/patches/patch_draft_mtp_int4.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""B70 Fase M1: MTP layer (draft) cuantizado a INT4 g128 sym (formato GPTQ).
+
+El modulo MTP del draft (Qwen3_5MultiTokenPredictor: fc + full_attention
+decoder layer) esta en BF16 (forzado por B70_MTP_BF16_DRAFT=1) y se lee
+~0.85 GB/paso (4 pasadas/paso = 3.4 GB). Cuantizar sus 5 linears
+(fc, qkv_proj, o_proj, gate_up_proj, down_proj) a INT4 g128 sym
+(~0.21 GB incl. scales) reusa el kernel YA existente
+``torch.ops._xpu_C.int4_gemm_w4a16`` (formato GPTQ del cuerpo) y elimina
+~2.6 GB/paso de lecturas de DRAM.
+
+Lossless: el target de verificacion no se toca; los tokens del draft se
+verifican contra el target (greedy) -> la secuencia emitida es identica.
+GATE de aceptacion: el draft INT4 puede proponer distinto; si la aceptacion
+baja >0.03 la ganancia de bytes puede perderse -> medir ANTES vs DESPUES.
+
+Mecanismo: los linears del MTP tienen ``quant_method`` (UnquantizedLinearMethod)
+cuyo ``apply(layer, x, bias)`` hace el matmul. Se intercambia ``quant_method``
+por un metodo duck-typed que rutea por int4_gemm_w4a16 con la copia INT4.
+El resto del layer (attention, rope, norms, silu) queda intacto.
+
+IMPORTANTE (compilacion): el hook va en ``Qwen3_5MTP.load_weights`` (eager,
+al cargar el modelo) y NO en forward: el forward de Qwen3_5MTP esta
+decorado con @support_torch_compile (AOT fullgraph) y una construccion
+lazy en forward rompe el trace de dynamo ("Failed to trace builtin operator
+print" en warmup). La construccion en load_weights corre antes de cualquier
+trace -> el grafo compilado ya ve los quant_method INT4.
+
+Env-gated: B70_DRAFT_MTP_INT4=1 (default off = comportamiento identico).
+Anclas verificadas contra la imagen vllm/vllm-openai-xpu@2c427ef (vLLM
+0.26.1.dev457.gc810e5ee9).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+MARKER = "B70_DRAFT_MTP_INT4"
+
+HELPER_MODULE = "b70_draft_mtp_int4.py"
+
+HELPER_SOURCE = '''\
+"""B70 Fase M1 runtime helper: draft MTP layer INT4 g128 sym.
+
+Escribido por patch_draft_mtp_int4.py dentro del contenedor. Provee la
+cuantizacion one-time de los 5 linears del modulo MTP del draft a GPTQ
+INT4 g128 sym y el ruteo por ``int4_gemm_w4a16``. El target queda intacto.
+"""
+from __future__ import annotations
+
+import os
+
+import torch
+
+
+def quantize_to_int4(weight: torch.Tensor, group_size: int = 128):
+    """Quantiza un peso [N, K] a GPTQ INT4 g128 sym (formato int4_gemm_w4a16).
+
+    Returns (qweight, scales, qzeros, group_size):
+      qweight: int32 [K//8, N] layout NT (strides[-2] == 1), nibbles
+               secuenciales LSB-first, valor almacenado = q + 8 (q in [-8, 7])
+      scales:  fp16 [K//group_size, N]
+      qzeros:  int8 tensor([8])  -> rama simetrica de int4_gemm_w4a16
+    """
+    device = weight.device
+    N, K = weight.shape
+    num_groups = K // group_size
+    chunk = 4096
+    shifts = torch.tensor(
+        [0, 4, 8, 12, 16, 20, 24, 28], dtype=torch.int32, device=device
+    )
+    parts = []
+    scale_parts = []
+    for i in range(0, N, chunk):
+        wc = weight[i : i + chunk].float()
+        wg = wc.view(wc.shape[0], num_groups, group_size)
+        maxabs = wg.abs().amax(dim=-1)
+        scale = maxabs / 7.0
+        q = (wg / scale.unsqueeze(-1)).round().clamp(-8, 7).to(torch.int32)
+        stored = q + 8
+        qv = stored.view(wc.shape[0], num_groups, group_size // 8, 8)
+        packed = (qv << shifts).sum(dim=-1).to(torch.int32).reshape(
+            wc.shape[0], K // 8
+        )
+        parts.append(packed)
+        scale_parts.append(scale.half())
+    qweight_contig = torch.cat(parts, dim=0)
+    scales_contig = torch.cat(scale_parts, dim=0)
+    qweight = qweight_contig.t()
+    scales = scales_contig.t().contiguous()
+    qzeros = torch.tensor([8], dtype=torch.int8, device=device)
+    return qweight, scales, qzeros, group_size
+
+
+def _collect_linears(predictor) -> list[tuple[str, torch.nn.Module]]:
+    """Lista (name, linear) de los 5 linears del MTP predictor a INT4."""
+    found: list[tuple[str, torch.nn.Module]] = []
+    found.append(("fc", predictor.fc))
+    for li, layer in enumerate(predictor.layers):
+        attn = getattr(layer, "self_attn", None)
+        if attn is not None:
+            found.append((f"layers.{li}.self_attn.qkv_proj", attn.qkv_proj))
+            found.append((f"layers.{li}.self_attn.o_proj", attn.o_proj))
+        mlp = getattr(layer, "mlp", None)
+        if mlp is not None:
+            gate_up = getattr(mlp, "gate_up_proj", None)
+            down = getattr(mlp, "down_proj", None)
+            if gate_up is not None:
+                found.append((f"layers.{li}.mlp.gate_up_proj", gate_up))
+            if down is not None:
+                found.append((f"layers.{li}.mlp.down_proj", down))
+    return found
+
+
+class _B70MTPInt4LinearMethod:
+    """Duck-typed quant_method: apply() rutea por int4_gemm_w4a16."""
+
+    def __init__(self, qweight, scales, qzeros, group_size):
+        self.qweight = qweight
+        self.scales = scales
+        self.qzeros = qzeros
+        self.group_size = group_size
+
+    def create_weights(self, *args, **kwargs):
+        pass
+
+    def process_weights_after_loading(self, *args, **kwargs):
+        pass
+
+    def apply(self, layer, x, bias):
+        flat = x.reshape(-1, x.shape[-1])
+        if flat.dtype != torch.float16:
+            flat = flat.to(torch.float16)
+        out = torch.ops._xpu_C.int4_gemm_w4a16(
+            flat, self.qweight, None, self.scales, self.qzeros,
+            self.group_size, None,
+        )
+        return out.reshape(*x.shape[:-1], self.qweight.shape[1])
+
+
+@torch.no_grad()
+def build_draft_mtp_int4(model) -> None:
+    """Cuantiza los linears del MTP predictor (one-time en load_weights; no-op
+    si no hay env gate o si ya se construyo). Almacena en
+    model._b70_mtp_int4_built."""
+    if os.environ.get("B70_DRAFT_MTP_INT4") != "1":
+        return
+    if getattr(model, "_b70_mtp_int4_built", False):
+        return
+    predictor = getattr(model, "model", None)
+    if predictor is None or not hasattr(predictor, "layers"):
+        print("[B70] draft MTP INT4: no Qwen3_5MultiTokenPredictor; "
+              "MTP queda en BF16", flush=True)
+        return
+    linears = _collect_linears(predictor)
+    if not linears:
+        print("[B70] draft MTP INT4: no linears encontrados; skip", flush=True)
+        return
+    print(f"[B70] draft MTP INT4: cuantizando {len(linears)} linears "
+          f"del MTP -> INT4 g128 sym (one-time)", flush=True)
+    total_fp16 = 0
+    total_int4 = 0
+    for name, lin in linears:
+        w = getattr(lin, "weight", None)
+        if w is None:
+            continue
+        orig_shape = tuple(w.shape)
+        qweight, scales, qzeros, gs = quantize_to_int4(w.detach())
+        lin._b70_mtp_int4 = _B70MTPInt4LinearMethod(
+            qweight, scales, qzeros, gs
+        )
+        lin.quant_method = lin._b70_mtp_int4
+        fp16_bytes = w.numel() * w.element_size()
+        int4_bytes = qweight.numel() * qweight.element_size() + (
+            scales.numel() * scales.element_size()
+        )
+        total_fp16 += fp16_bytes
+        total_int4 += int4_bytes
+        with torch.no_grad():
+            lin.weight.set_(
+                torch.empty(0, dtype=w.dtype, device=w.device)
+            )
+        print(f"[B70] draft MTP INT4: {name} {orig_shape} "
+              f"{fp16_bytes/1e6:.0f} MB -> {int4_bytes/1e6:.0f} MB "
+              f"(fp16 liberado)", flush=True)
+    model._b70_mtp_int4_built = True
+    print(f"[B70] draft MTP INT4: listo. {total_fp16/1e9:.2f} GB BF16 -> "
+          f"{total_int4/1e9:.2f} GB INT4 (ahorro "
+          f"{(total_fp16 - total_int4)/1e6:.0f} MB/lectura)", flush=True)
+'''
+
+QWMTP_FORWARD_OLD = (
+    "        loader = AutoWeightsLoader(self)\n"
+    "        return loader.load_weights(remap_weight_names(weights))\n"
+)
+QWMTP_FORWARD_NEW = (
+    "        loader = AutoWeightsLoader(self)\n"
+    "        result = loader.load_weights(remap_weight_names(weights))\n"
+    "        if os.environ.get(\"B70_DRAFT_MTP_INT4\") == \"1\":\n"
+    "            from vllm.model_executor.models.b70_draft_mtp_int4 import (\n"
+    "                build_draft_mtp_int4,\n"
+    "            )\n"
+    "\n"
+    "            build_draft_mtp_int4(self)\n"
+    "        return result\n"
+)
+
+
+def _write_helper(vllm_dir: str) -> str:
+    models_dir = os.path.join(vllm_dir, "model_executor", "models")
+    os.makedirs(models_dir, exist_ok=True)
+    path = os.path.join(models_dir, HELPER_MODULE)
+    existing = None
+    if os.path.exists(path):
+        existing = open(path).read()
+    if existing == HELPER_SOURCE:
+        print(f"helper already present {path}")
+        return path
+    with open(path, "w") as f:
+        f.write(HELPER_SOURCE)
+    print(f"helper written {path}")
+    return path
+
+
+def _patch_qwen3_5_mtp(vllm_dir: str) -> None:
+    path = os.path.join(vllm_dir, "model_executor", "models", "qwen3_5_mtp.py")
+    text = open(path).read()
+    if MARKER in text:
+        print(f"already patched {path}")
+        return
+    if QWMTP_FORWARD_OLD not in text:
+        sys.exit(f"anchor not found in {path}: Qwen3_5MTP.forward")
+    text = text.replace(QWMTP_FORWARD_OLD, QWMTP_FORWARD_NEW, 1)
+    if "\nimport os\n" not in text and not text.startswith("import os\n"):
+        text = text.replace("import torch\n", "import os\nimport torch\n", 1)
+        if "\nimport os\n" not in text and not text.startswith("import os\n"):
+            sys.exit(f"could not inject import os in {path}")
+    compile(text, path, "exec")
+    open(path, "w").write(text)
+    print(f"patched {path}")
+
+
+def main() -> None:
+    import vllm
+
+    vllm_dir = os.path.dirname(vllm.__file__)
+    _write_helper(vllm_dir)
+    _patch_qwen3_5_mtp(vllm_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Runtime patches that requantize the **speculative-draft** side of MTP to INT4 g128 symmetric (round-to-nearest) and route those linears through `torch.ops._xpu_C.int4_gemm_w4a16`. Env default **off**.

The target body and verify LM head stay as in the cookbook recipe. Draft logits are not identical to BF16, so acceptance can move — do not call this lossless.

## Do not headline +51%

The earlier 117.1 vs 83.7 table mixed two stacks (legacy `2c427ef` + six patches + MBT 4096 + cache on vs champion `f01e24f6` + two patches + MBT 8192 + cache off). That is not a same-image Phase S / S+M1 A/B.

## Same-image screen (`f01e24f6`, n=3, 230 W, cache off, MBT 8192)

| Setup | p512/g128 median post-first | p8192/g1 input/TTFT | 15-turn agentic median |
|---|---:|---:|---:|
| cookbook MTP4 | 59.1 t/s (~p530) | 1748 t/s (~p4130) | 44.3 t/s |
| compact+scatter only | 62.7 | 1746 | 44.4 |
| compact+scatter + draft INT4 S+M1 | **83.9** | 1757 | **59.6** |

Prefill is flat. 83.9 matches the published Run 40 card (83.7 n=5 exact p512); it does not beat it. Acceptance counters were empty. Still need n≥5 exact-token C1 plus `spec_decode` accepted/proposed before this is a recipe keep.

Pair with the compact+scatter GDN split from PR #1 if you also need mixed spec + prefill. The original full-buffer split is OOB on kernels `0.1.12.3`.
