### PR TITLE
windows: KV headroom, stderr false-positive fix, NEO abort workaround

### DIFF
--- a/docs/IMAGE-AND-PATCH-MATRIX.md
+++ b/docs/IMAGE-AND-PATCH-MATRIX.md
@@ -22,7 +22,8 @@ Qwen3.8 `f01e24f6` digest. Image tag **2026.08.19** applies the Qwen MTP pair
 (SHA-256-verified against `5c6b6b1`) **and** the optional mixed-split v5 +
 draft-INT4 S+M1 patches, with prefix cache **on** for serving. `DRAFT_INT4=0`
 recovers the 18 August BF16-draft path. Display-attached VRAM pin (0.75 +
-4.25 GiB fp8 KV, 100K) is unchanged.
+4.30 GiB fp8 KV, 100K; bumped from 4.25 on 2026-08-22 for headroom) is
+otherwise unchanged.
 
 Nemotron-3.5-Lightning DFlash is a **second generation**. It uses a newer
 public digest than the Qwen3.6 Pi matrix below. Do not mix patch lists.

--- a/docs/qwen38-27/WINDOWS-STANDALONE.md
+++ b/docs/qwen38-27/WINDOWS-STANDALONE.md
@@ -47,7 +47,7 @@ So both kits pin, instead of negotiating:
 | Lever | Value | Effect |
 |---|---|---|
 | `GPU_MEMORY_UTILIZATION` | **0.75** | Leaves ~8 GiB of the card for Windows, the display server and Docker Desktop's WSL VM |
-| `--kv-cache-memory-bytes` | **4563402752** (exactly 4.25 GiB) | No auto-sizing surprise; reported capacity 102,631 tokens at 100K context (1.03× concurrency) |
+| `--kv-cache-memory-bytes` | **4617089843** (exactly 4.30 GiB) | No auto-sizing surprise; reported capacity 102,631 tokens at 100K context (1.03× concurrency). Bumped from 4.25 GiB on 2026-08-22: some Windows hosts need 4.26 GiB for 100K (mamba page alignment + padding layers) and failed boot by ~10 MiB (issue #4) |
 | `--kv-cache-dtype` | **fp8** | Same requirement as Linux dense 27B — fp16 KV does not fit |
 | `MAX_NUM_SEQS` | **1** | Single-user desktop serving; this is **not** the concurrent Cn profile |
 
@@ -99,7 +99,7 @@ What changed in **2026.08.19**:
 | Prefix cache | off | **on** (real multi-turn sessions). Turn it off only for a cold decode test |
 | Sampling | template only | `--generation-config auto` (Qwen thinking / non-thinking defaults) |
 | Image tag | `qwen38-b70-docker:2026.08.18` / `qwen38-b70-friendly:2026.08.18` | `…:2026.08.19` |
-| Display-safe VRAM | 0.75 + 4.25 GiB fp8 KV, 100K, MTP4, C1 | **unchanged** |
+| Display-safe VRAM | 0.75 + 4.25 GiB fp8 KV, 100K, MTP4, C1 | same pin; KV default later bumped 4.25 → 4.30 GiB for headroom (see [Troubleshooting](#troubleshooting-windows)) |
 
 Linux, same overlay, C1, n=5, cache **off**: **112.65** vs matched BF16-draft **81.20** tok/s at p512/g128. Prefill is flat. Quality KEEP on the 12/15 coding gate. That is a Linux campaign, not a Windows re-measure. On Windows expect “noticeably faster than your ~70”, not a copied 112.
 
@@ -253,7 +253,7 @@ kit folder you downloaded (or `windows/Qwen38-*-Standalone/` from this repo).
 3. **Daily controls:**
 
    ```powershell
-   .\Start-Qwen38.ps1 -MtpTokens 4 -MaxModelLength 100000 -GpuMemoryUtilization 0.75 -KvCacheMemoryGiB 4.25 -KvCacheDtype fp8
+   .\Start-Qwen38.ps1 -MtpTokens 4 -MaxModelLength 100000 -GpuMemoryUtilization 0.75 -KvCacheMemoryGiB 4.3 -KvCacheDtype fp8
    .\Stop-Qwen38.ps1
    .\Stop-Qwen38.ps1 -ReleaseGpuMemory   # terminates the WSLC session to return ALL GPU memory to Windows
    .\Test-B70Gpu.ps1                      # standalone B70 passthrough + XPU probe
@@ -316,6 +316,40 @@ this fix, `git pull` and rebuild (`.\Upgrade-Qwen38-Docker.ps1` or
 - **Slow first model load is expected:** weights are read from a Windows bind
   mount through WSL's 9P file system; the Docker kit preserves the stopped
   container to keep its compiled-graph cache.
+
+## Troubleshooting (Windows)
+
+**Red `NativeCommandError` text while the container is actually fine.**
+vLLM (and `docker`/`wslc` themselves) write progress and INFO lines to stderr,
+and PowerShell with `$ErrorActionPreference = "Stop"` can promote that harmless
+stderr text into a terminating `NativeCommandError`, killing the readiness loop
+of older kit copies. The start and download scripts now capture native stderr
+inside a `Continue` scope, so `git pull` fixes it. If you see the red text on an
+old copy while `http://127.0.0.1:8000/v1/models` responds, the server is fine —
+update the kit and rerun.
+
+**Intel NEO `linear_stream.h` abort under sustained load.** With XPU graphs on
+and Level Zero's default immediate command lists, long agent sessions could
+abort the engine (`Abort was called at 90 line in file:
+.../linear_stream.h`, then `EngineDeadError`). Both start scripts now set
+`SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0` by default — the
+reporter-verified workaround from issue #6, which stopped the aborts while
+keeping graph-enabled speed (~104–106 tok/s short decode). Existing containers
+keep their old env: recreate with `.\Start-Qwen38-Docker.ps1 -Recreate` (or the
+WSLC twin) to pick it up.
+
+**Throughput and MTP acceptance degrade over hours, server stays alive.**
+One Windows reporter (issue #6) observed short-decode falling from ~104 to
+~19 tok/s, MTP acceptance from ~99% to ~70%, and TGP from ~120 W to ~82 W after
+an ~85-minute Hermes session, with the endpoint still responsive. A plain
+`docker restart` (or `.\Stop-Qwen38-Docker.ps1` + `.\Start-Qwen38-Docker.ps1`)
+restored full performance with no configuration change. This reads as a
+long-running runtime-state degradation (vLLM XPU / Level Zero), not a cookbook
+configuration error; it is not root-caused yet and is tracked in issue #6. If
+you hit it: restart the container, and if it recurs, post your env plus
+`docker logs` to the issue. The open isolation matrix there is BF16 draft
+(`-DraftInt4 0`), MTP2, graphs off, and a repeated-benchmark control without
+Hermes.
 
 ## Measured results — self-reported, one Windows machine
 

--- a/windows/Qwen38-Docker-Standalone/README.md
+++ b/windows/Qwen38-Docker-Standalone/README.md
@@ -143,7 +143,7 @@ Copy the repository contents directly into that folder. It must contain
 - Model name: `qwen38`
 - Tools: enabled with the `qwen3_coder` parser
 - Vision: disabled
-- Profile: MTP4, 100K context, FP8 KV cache, explicit 4.25 GiB cache,
+- Profile: MTP4, 100K context, FP8 KV cache, explicit 4.30 GiB cache,
   draft-INT4 overlay on, prefix cache on
 
 The first image build and model download can take a long time. Model loading is

--- a/windows/Qwen38-Docker-Standalone/Start-Qwen38-Docker.ps1
+++ b/windows/Qwen38-Docker-Standalone/Start-Qwen38-Docker.ps1
@@ -21,7 +21,7 @@ Write-Host "Windows container devised and tested by Ian Hudson - aitesthive.com"
 Write-Host ""
 Write-Host "[Docker] Starting the Qwen3.8-27B server on the Intel Arc Pro B70."
 Write-Host "[Docker] Model: Qwen3.8-27B GPTQ INT4 with MTP4"
-Write-Host "[Docker] Context: 100,000 tokens; explicit FP8 KV cache: 4.25 GiB"
+Write-Host "[Docker] Context: 100,000 tokens; explicit FP8 KV cache: 4.30 GiB"
 Write-Host "[Docker] Draft INT4 overlay: $(if ($DraftInt4 -eq 1) { 'ON (default, 2026.08.19)' } else { 'OFF (BF16 draft)' })"
 Write-Host "[Docker] Prefix cache: $(if ($PrefixCache -eq 1) { 'ON (default, real sessions)' } else { 'OFF (decode-test only)' })"
 
@@ -70,10 +70,17 @@ if ($containerExists) {
         "-e", "CCL_ENABLE_SYCL_KERNELS=0", "-e", "CCL_TOPO_P2P_ACCESS=0",
         "-e", "CCL_TOPO_FABRIC_VERTEX_CONNECTION_CHECK=0", "-e", "CCL_ZE_CACHE_OPEN_IPC_HANDLES=0",
         "-e", "SYCL_UR_USE_LEVEL_ZERO_V2=0", "-e", "TORCH_LLM_ALLREDUCE=1",
+        # The default immediate-command-list path can abort in Intel NEO
+        # (linear_stream.h) under sustained graph-enabled load; =0 stopped the
+        # aborts while keeping graph speed in reporter testing (issue #6).
+        "-e", "SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0",
         "-e", "MTP_TOKENS=4", "-e", "MAX_MODEL_LEN=100000", "-e", "KV_CACHE_DTYPE=fp8",
         "-e", "DRAFT_INT4=$DraftInt4", "-e", "PREFIX_CACHE=$PrefixCache",
         "-e", "MAX_NUM_SEQS=1", "-e", "GPU_MEMORY_UTILIZATION=0.75",
-        "-e", "KV_CACHE_MEMORY_BYTES=4563402752", $ImageName
+        # 4.30 GiB: some Windows hosts need 4.26 GiB for the 100K context
+        # (mamba page alignment + padding layers), so 4.25 GiB failed their
+        # engine boot by ~10 MiB (issue #4). Small deliberate over-allocation.
+        "-e", "KV_CACHE_MEMORY_BYTES=4617089843", $ImageName
     )
     & $docker @args | Out-Null
     if ($LASTEXITCODE -ne 0) { throw "Docker container creation failed with exit code $LASTEXITCODE." }
@@ -95,11 +102,17 @@ do {
 
     $status = (& $docker inspect --format '{{.State.Status}} {{.State.ExitCode}}' $ContainerName 2>$null)
     if ($status -notmatch '^running ') {
-        & $docker logs --tail 80 $ContainerName
+        & { $ErrorActionPreference = "Continue"; & $docker logs --tail 80 $ContainerName 2>&1 }
         throw "The Docker server exited before its API became ready ($status)."
     }
 
-    $logs = (& $docker logs --tail 120 $ContainerName 2>&1) -join "`n"
+    # vLLM writes its progress to stderr; capture it in a Continue scope so
+    # PowerShell cannot promote harmless stderr text into a terminating
+    # NativeCommandError and kill the readiness loop (issue #5).
+    $logs = & {
+        $ErrorActionPreference = "Continue"
+        (& $docker logs --tail 120 $ContainerName 2>&1) -join "`n"
+    }
     $stage = if ($logs -match 'Loading safetensors checkpoint shards:\s+(\d+)%') {
         "Loading model checkpoint shards ($($Matches[1])% of the current checkpoint pass)"
     } elseif ($logs -match 'torch\.compile') {

--- a/windows/Qwen38-WSLC-Standalone/Download-Qwen38Model.ps1
+++ b/windows/Qwen38-WSLC-Standalone/Download-Qwen38Model.ps1
@@ -54,9 +54,11 @@ if ((Test-Path -LiteralPath $configPath) -and $shards.Count -eq $ExpectedShards)
     return
 }
 
-$listText = (& wslc.exe list --all --no-trunc 2>&1 | Out-String)
+# WSLC answers "not found" on stderr; capture in a Continue scope so
+# PowerShell cannot promote it into a terminating NativeCommandError (issue #5).
+$listText = & { $ErrorActionPreference = "Continue"; (& wslc.exe list --all --no-trunc 2>&1 | Out-String) }
 if ($listText -match [regex]::Escape($DownloadContainer)) {
-    $downloadInspect = ((& wslc.exe inspect $DownloadContainer 2>&1 | Out-String) | ConvertFrom-Json)[0]
+    $downloadInspect = (& { $ErrorActionPreference = "Continue"; (& wslc.exe inspect $DownloadContainer 2>&1 | Out-String) } | ConvertFrom-Json)[0]
     if ($downloadInspect.State.Running) {
         Write-Host "[Download] Another Qwen3.8 download container is already running." -ForegroundColor Yellow
         Write-Host "Container: $DownloadContainer"
@@ -109,7 +111,7 @@ try {
     if ($LASTEXITCODE -ne 0) { throw "Model download failed with exit code $LASTEXITCODE" }
 } finally {
     # --rm normally handles this; explicit cleanup covers interrupted clients.
-    $containersAfterDownload = (& wslc.exe list --all --no-trunc 2>&1 | Out-String)
+    $containersAfterDownload = & { $ErrorActionPreference = "Continue"; (& wslc.exe list --all --no-trunc 2>&1 | Out-String) }
     if ($containersAfterDownload -match [regex]::Escape($DownloadContainer)) {
         Write-Host "[Cleanup] Removing the download container..."
         & wslc.exe remove --force $DownloadContainer | Out-Null

--- a/windows/Qwen38-WSLC-Standalone/README.md
+++ b/windows/Qwen38-WSLC-Standalone/README.md
@@ -91,9 +91,9 @@ Copy the repository contents directly into that folder. It must contain
 ## Main controls
 
 ```powershell
-.\Start-Qwen38.ps1 -MtpTokens 4 -MaxModelLength 100000 -GpuMemoryUtilization 0.75 -KvCacheMemoryGiB 4.25 -KvCacheDtype fp8
-.\Start-Qwen38.ps1 -MtpTokens 4 -MaxModelLength 100000 -GpuMemoryUtilization 0.75 -KvCacheMemoryGiB 4.25 -KvCacheDtype fp8 -PrefixCache 0
-.\Start-Qwen38.ps1 -MtpTokens 4 -MaxModelLength 100000 -GpuMemoryUtilization 0.75 -KvCacheMemoryGiB 4.25 -KvCacheDtype fp8 -DraftInt4 0
+.\Start-Qwen38.ps1 -MtpTokens 4 -MaxModelLength 100000 -GpuMemoryUtilization 0.75 -KvCacheMemoryGiB 4.3 -KvCacheDtype fp8
+.\Start-Qwen38.ps1 -MtpTokens 4 -MaxModelLength 100000 -GpuMemoryUtilization 0.75 -KvCacheMemoryGiB 4.3 -KvCacheDtype fp8 -PrefixCache 0
+.\Start-Qwen38.ps1 -MtpTokens 4 -MaxModelLength 100000 -GpuMemoryUtilization 0.75 -KvCacheMemoryGiB 4.3 -KvCacheDtype fp8 -DraftInt4 0
 .\Stop-Qwen38.ps1
 ```
 
@@ -108,7 +108,7 @@ Copy the repository contents directly into that folder. It must contain
 - Model name: `qwen38`
 - Tools: automatic tool choice enabled with the `qwen3_coder` parser
 - Vision: disabled
-- Profile: MTP4, 100K context, FP8 KV cache, explicit 4.25 GiB cache,
+- Profile: MTP4, 100K context, FP8 KV cache, explicit 4.30 GiB cache,
   draft-INT4 overlay on, prefix cache on
 
 Startup and model download can take several minutes. The setup script prints

--- a/windows/Qwen38-WSLC-Standalone/Start-Qwen38.ps1
+++ b/windows/Qwen38-WSLC-Standalone/Start-Qwen38.ps1
@@ -27,8 +27,9 @@ if (-not (Test-Path -LiteralPath (Join-Path $ModelDirectory "config.json"))) {
 
 # Replacement is intentionally scoped to this project's fixed container name.
 # Query first because PowerShell can promote WSLC's harmless "not found"
-# stderr response into a terminating NativeCommandError.
-$containerList = (& wslc.exe list --all --no-trunc 2>&1 | Out-String)
+# stderr response into a terminating NativeCommandError, so every native
+# stderr capture below runs in a Continue scope (issue #5).
+$containerList = & { $ErrorActionPreference = "Continue"; (& wslc.exe list --all --no-trunc 2>&1 | Out-String) }
 if ($containerList -match [regex]::Escape($ContainerName)) {
     Write-Host "[Server] Removing the previous $ContainerName container..."
     & wslc.exe remove --force $ContainerName
@@ -82,6 +83,10 @@ $run = @(
     "--env", "CCL_TOPO_FABRIC_VERTEX_CONNECTION_CHECK=0",
     "--env", "CCL_ZE_CACHE_OPEN_IPC_HANDLES=0",
     "--env", "SYCL_UR_USE_LEVEL_ZERO_V2=0",
+    # The default immediate-command-list path can abort in Intel NEO
+    # (linear_stream.h) under sustained graph-enabled load; =0 stopped the
+    # aborts while keeping graph speed in reporter testing (issue #6).
+    "--env", "SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0",
     "--env", "TORCH_LLM_ALLREDUCE=1",
     "--env", "MTP_TOKENS=$MtpTokens",
     "--env", "MAX_MODEL_LEN=$MaxModelLength",
@@ -123,7 +128,7 @@ while ((Get-Date) -lt $deadline) {
         $containerExited = $false
         $containerExitCode = $null
         try {
-            $inspectText = (& wslc.exe inspect $ContainerName 2>&1 | Out-String)
+            $inspectText = & { $ErrorActionPreference = "Continue"; (& wslc.exe inspect $ContainerName 2>&1 | Out-String) }
             $inspectData = $inspectText | ConvertFrom-Json
             $containerState = $inspectData[0].State
             if (-not $containerState.Running) {
@@ -138,14 +143,14 @@ while ((Get-Date) -lt $deadline) {
             Write-Host "[Server] Exit code: $containerExitCode"
             Write-Host ""
             Write-Host "[Server] Final log output:" -ForegroundColor Yellow
-            & wslc.exe logs $ContainerName | Select-Object -Last 100
+            & { $ErrorActionPreference = "Continue"; & wslc.exe logs $ContainerName 2>&1 } | Select-Object -Last 100
             throw "Qwen3.8 server startup failed with container exit code $containerExitCode."
         }
 
         # vLLM does not publish a true loading percentage. Infer a useful
         # human-readable stage from its latest log output instead.
         try {
-            $recentLogs = (& wslc.exe logs $ContainerName 2>&1 | Select-Object -Last 250 | Out-String)
+            $recentLogs = & { $ErrorActionPreference = "Continue"; (& wslc.exe logs $ContainerName 2>&1 | Select-Object -Last 250 | Out-String) }
             $shardMatches = [regex]::Matches(
                 $recentLogs,
                 '(?im)(?:shard|checkpoint shard)[^\r\n]*?(\d+)\s*(?:of|/)\s*(\d+)'


### PR DESCRIPTION
Addresses the three open Windows field reports:

- **Fixes #4** — KV cache 10 MiB too small: `Start-Qwen38-Docker.ps1` pinned 4563402752 (4.25 GiB) but vLLM needs 4.26 GiB for the 100K context on some Windows hosts (mamba page alignment to 1664-token pages + 3 padding layers), so engine boot failed. Default bumped to 4617089843 (exactly 4.30 GiB — the value @fm0322 already ran successfully for 85 min); docs and READMEs updated, WSLC examples to `-KvCacheMemoryGiB 4.3`.
- **Fixes #5** — false-positive `NativeCommandError`: vLLM logs INFO/progress to stderr and the readiness loop captured `docker logs ... 2>&1` under `ErrorActionPreference=Stop`, so PowerShell killed the script while the container was healthy. All native stderr captures (Docker start, WSLC start + download) now run in a `Continue` scope.
- **Addresses #6** — `SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0` is now the default in both start scripts (reporter-verified: stops the Intel NEO `linear_stream.h` aborts under sustained graph-enabled load while keeping ~104-106 tok/s), plus a new **Troubleshooting (Windows)** section in `WINDOWS-STANDALONE.md` documenting the abort, the workaround, and the long-run MTP degradation symptom with the `docker restart` recovery. The degradation itself remains open/tracked in #6 (upstream runtime-state suspect).

Existing containers keep their old env; `-Recreate` picks the new defaults up. No image rebuild required (env-only changes).